### PR TITLE
fix: should be able to parse options with/without equals sign (`=`)

### DIFF
--- a/src/__tests__/parse-args.spec.ts
+++ b/src/__tests__/parse-args.spec.ts
@@ -744,4 +744,12 @@ describe('parseArgs', () => {
     const result = parseArgs(configWithDefault);
     expect(result.follow).toBe(true);
   });
+
+  it('should parse options passed with = (equals sign)', () => {
+    const args = ['file1.txt', 'output/', '--exclude=pattern1', '-e=pattern2', '--bar=value'];
+    vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+    const result = parseArgs(config);
+    expect(result.exclude).toEqual(['pattern1', 'pattern2']);
+    expect(result.bar).toBe('value');
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,15 @@ export type * from './interfaces.js';
 
 export function parseArgs(config: Config): Record<string, any> {
   const { command, options, version } = config;
-  const args = process.argv.slice(2);
+
+  // Normalize args to support --option=value and -o=value
+  const args = process.argv.slice(2).flatMap(arg => {
+    if (/^--?\w[\w-]*=/.test(arg)) {
+      const [flag, ...rest] = arg.split('=');
+      return [flag, rest.join('=')];
+    }
+    return arg;
+  });
   const result: Record<string, any> = {};
 
   // Check for duplicate aliases


### PR DESCRIPTION
Parsing options with equal sign (`=`) wasn't previously working, these 2 options should work:
- `command --exclude pattern1`
- `command --exclude=pattern1`