### PR TITLE
chore: exclude scripts folder from test coverage

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
       interopDefault: false,
     },
     coverage: {
-      exclude: [...configDefaults.exclude, '**/interfaces.ts', '**/examples/**', '*.mjs'],
+      exclude: [...configDefaults.exclude, '**/interfaces.ts', '**/examples/**', '**/scripts/**', '*.mjs'],
     },
     watch: false,
   },


### PR DESCRIPTION
- the scripts are only used for publishing on npm, it has nothing to do with the library itself