### PR TITLE
refactor: remove help/version consoles & use built-in options logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ const config: Config = {
     }
   },
   version: '0.1.6',
+  helpOptLength: 18,  // option name length shown in help (defaults to 20)
+  helpDescLength: 60, // description length shown in help (defaults to 65)
 };
 
 const args = parseArgs(config);
@@ -174,3 +176,31 @@ See [examples/](examples/) for more usage patterns.
 
 - [native-copyfiles](https://github.com/ghiscoding/native-copyfiles)
 - [remove-glob](https://github.com/ghiscoding/remove-glob)
+
+## Help Example
+
+You can see below an example of a CLI help (which is the result of calling `--help` with the config shown avove). 
+
+Please note:
+
+- `<option>` → required
+- `[option]` → optional
+
+```
+Usage:
+  serve <input..> [port] [options]  Start a server with the given options
+
+Arguments:
+  input             serving files or directory                                   <string..>
+  port              port to bind on                                              [number]
+
+Options:
+  -d, --dryRun      Show what would be done, but do not actually start the se... [boolean]
+  -e, --exclude     pattern or glob to exclude (may be passed multiple times)    [array]
+  -r, --rainbow     Enable rainbow mode                                          [boolean]
+  -V, --verbose     print more information to console                            [boolean]
+      --up          slice a path off the bottom of the paths                     [number]
+  -D, --display     a required display option                                    <boolean>
+  -h, --help        Show help                                                    [boolean]
+  -v, --version     Show version number                                          [boolean]
+```

--- a/examples/cli.js
+++ b/examples/cli.js
@@ -59,6 +59,8 @@ const config = {
     },
   },
   version: '0.1.6',
+  helpOptLength: 18, // option name length shown in help (defaults to 20)
+  helpDescLength: 60, // description length shown in help (defaults to 65)
 };
 
 const results = parseArgs(config);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "preview:release": "release-it --only-version --dry-run",
     "release": "release-it --only-version",
     "preview:cli:help": "node examples/cli.js --help",
+    "preview:cli:version": "node examples/cli.js --version",
     "prepack": "node scripts/prepack.js",
     "postpack": "node scripts/postpack.js",
     "test": "vitest --watch --config ./vitest.config.mts",

--- a/src/__tests__/parse-args.spec.ts
+++ b/src/__tests__/parse-args.spec.ts
@@ -264,7 +264,6 @@ describe('parseArgs', () => {
         expect(consoleLogSpy).toHaveBeenCalledWith(
           expect.stringContaining('  -b, --bar           a required bar option                                             <string>'),
         );
-        expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('\nDefault options:'));
         expect(consoleLogSpy).toHaveBeenCalledWith(
           expect.stringContaining('  -h, --help          Show help                                                         [boolean]'),
         );
@@ -432,6 +431,7 @@ describe('parseArgs', () => {
           type: 'string',
         },
       },
+      version: undefined,
     };
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', '--help']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import type { ArgsResult, ArgumentOptions, Config } from './interfaces.js';
-import { camelToKebab, kebabToCamel } from './utils.js';
 
 export type * from './interfaces.js';
 
@@ -267,4 +266,14 @@ function printHelp(config: Config) {
       `  ${aliasStr.padEnd(4)}--${formatHelpText(key, helpOptLength - 6)}${formatHelpText(option.description || '', helpDescLength)} ${formatOptionType(option.type, false, option.required)}`,
     );
   }
+}
+
+/** Utility to convert kebab-case to camelCase */
+function kebabToCamel(str: string) {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/** Utility to convert camelCase to kebab-case */
+function camelToKebab(str: string) {
+  return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import type { ArgsResult, ArgumentOptions, Config } from './interfaces.js';
-import { camelToKebab, kebabToCamel, padString } from './utils.js';
+import { camelToKebab, kebabToCamel } from './utils.js';
 
 export type * from './interfaces.js';
+
+const defaultOptions: Record<string, ArgumentOptions> = {
+  help: { alias: 'h', description: 'Show help', type: 'boolean' },
+  version: { alias: 'v', description: 'Show version number', type: 'boolean' },
+};
 
 export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
   const { command, options, version } = config;
@@ -253,19 +258,13 @@ function printHelp(config: Config) {
   });
 
   console.log('\nOptions:');
-  Object.keys(options).forEach(key => {
-    const option = options[key];
+  for (const [key, option] of Object.entries({ ...options, ...defaultOptions })) {
     const aliasStr = option.alias ? `-${option.alias}, ` : '';
+    if (!version && key === 'version') {
+      continue;
+    }
     console.log(
       `  ${aliasStr.padEnd(4)}--${formatHelpText(key, helpOptLength - 6)}${formatHelpText(option.description || '', helpDescLength)} ${formatOptionType(option.type, false, option.required)}`,
     );
-  });
-
-  // Print default options (help and version)
-  console.log('\nDefault options:');
-  console.log(`${padString('  -h, --help', 21)} ${padString('Show help', helpDescLength)} [boolean]`);
-  if (version) {
-    console.log(`${padString('  -v, --version', 21)} ${padString('Show version number', helpDescLength)} [boolean]`);
   }
-  console.log('\n');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,0 @@
-/** Utility to convert kebab-case to camelCase */
-export function kebabToCamel(str: string) {
-  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-}
-
-/** Utility to convert camelCase to kebab-case */
-export function camelToKebab(str: string) {
-  return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,3 @@ export function kebabToCamel(str: string) {
 export function camelToKebab(str: string) {
   return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 }
-
-/** add whitespace padding to any input string */
-export function padString(input: string, padding: number) {
-  return input.padEnd(padding);
-}


### PR DESCRIPTION
We can refactor the code and decrease project size by simply extending the options with default options and simply reuse the same logging as all other options