### PR TITLE
feat: add `helpFlagCasing` to show flag in camel or kebab (default) case

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ const config: Config = {
     },
   },
   version: '0.1.6',
+  helpFlagCasing: 'camel',    // show help flag option in which text casing (camel or kebab) (defaults to 'kebab')
   minHelpDescLength: 40,  // min description length shown in help (defaults to 50)
   maxHelpDescLength: 120, // max description length shown in help (defaults to 100), will show ellipsis (...) when greater
 };

--- a/examples/cli.js
+++ b/examples/cli.js
@@ -70,6 +70,7 @@ const config = {
     },
   },
   version: '0.1.6',
+  // helpFlagCasing: 'camel',
   maxDescLength: 125, // max description length shown in help
 };
 

--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -81,7 +81,9 @@ const config = {
     },
   },
   version: readPackage(),
-  maxDescLength: 125, // max description length shown in help
+  // helpFlagCasing: 'camel', // show help flag option in which text casing (camel or kebab) (defaults to 'kebab')
+  minHelpDescLength: 40, // min description length shown in help (defaults to 50)
+  maxHelpDescLength: 120, // max description length shown in help (defaults to 100), will show ellipsis (...) when greater
 } as const;
 
 const args = parseArgs<typeof config>(config);

--- a/src/__tests__/parse-args.spec.ts
+++ b/src/__tests__/parse-args.spec.ts
@@ -256,7 +256,7 @@ describe('parseArgs', () => {
           expect.stringContaining('  inFile          source files                                                    <string>'),
         );
         expect(consoleLogSpy).toHaveBeenCalledWith(
-          expect.stringContaining('  -d, --dryRun    Show what would be copied, but do not actually copy any files   [boolean]'),
+          expect.stringContaining('  -d, --dry-run   Show what would be copied, but do not actually copy any files   [boolean]'),
         );
         expect(consoleLogSpy).toHaveBeenCalledWith(
           expect.stringContaining('  -b, --bar       a required bar option                                           <string>'),
@@ -312,7 +312,7 @@ describe('parseArgs', () => {
       const configWithGroups: Config = {
         ...config,
         options: {
-          foo: {
+          fooBar: {
             alias: 'f',
             type: 'boolean',
             describe: 'foo option',
@@ -331,6 +331,7 @@ describe('parseArgs', () => {
             group: 'Group 2',
           },
         },
+        helpFlagCasing: 'camel',
       };
       const args = ['--help'];
       vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
@@ -339,7 +340,7 @@ describe('parseArgs', () => {
       } catch {
         expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('\nGroup 1:'));
         expect(consoleLogSpy).toHaveBeenCalledWith(
-          expect.stringContaining('  -f, --foo       foo option                                           [boolean]'),
+          expect.stringContaining('  -f, --fooBar    foo option                                           [boolean]'),
         );
         expect(consoleLogSpy).toHaveBeenCalledWith(
           expect.stringContaining('  -b, --bar       bar option                                           [boolean]'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,8 @@ function printHelp(config: Config) {
   let longestOptNameLn = 0;
   let longestOptDescLn = 0;
   for (const [key, option] of Object.entries({ ...options, ...defaultOptions })) {
-    if ((key?.length ?? 0) > longestOptNameLn) {
+    const flagLn = (config.helpFlagCasing === 'camel' ? key : camelToKebab(key)).length;
+    if (flagLn > longestOptNameLn) {
       longestOptNameLn = key.length;
     }
     if ((option.describe?.length ?? 0) > longestOptDescLn) {
@@ -300,8 +301,9 @@ function printHelp(config: Config) {
       if (!version && key === 'version') {
         return;
       }
+      const flagName = config.helpFlagCasing === 'camel' ? key : camelToKebab(key);
       console.log(
-        `  ${aliasStr.padEnd(4)}--${formatHelpText(key, longestOptNameLn)}${formatHelpText(option.describe || '', longestOptDescLn)} ${formatOptionType(option.type, false, option.required)}`,
+        `  ${aliasStr.padEnd(4)}--${formatHelpText(flagName, longestOptNameLn)}${formatHelpText(option.describe || '', longestOptDescLn)} ${formatOptionType(option.type, false, option.required)}`,
       );
     });
   });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,6 +51,12 @@ export interface Config {
   /** CLI definition */
   command: CommandOption;
 
+  /**
+   * Show flag option in which casing (camelCase or kebab-case) in the help (defaults to 'kebab').
+   * Note: this is only for the help print, the parsing will always support both camel/kebab casing
+   */
+  helpFlagCasing?: 'camel' | 'kebab';
+
   /** min description length shown in the help (defaults to 50) */
   minHelpDescLength?: number;
 


### PR DESCRIPTION
this option is only meant for the help printing, the CLI parsing will always accept and parse both casing.