### PR TITLE
feat(parser): support interleaved positional arguments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm run build
 
       - name: Run Unit Tests
-        run: npm run test:coverage
+        run: npm run test
 
       - name: Upload test coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Small library to create command-line tool (aka CLI) which is quite similar to [`
 - Parses arguments
 - Supports defining Positional arguments (input args)
   - Supports Variadic arguments (1 or more positional args)
+  - Interleaved positionals — positionals may appear anywhere in the arg list (enabled by default). Set `command.allowInterleaved = false` to disable.
 - Automatically converts flags to camelCase to match config options
   - accepts both `--camelCase` and `--kebab-case`
 - Negates flags when using the `--no-` prefix
+- Clustered short flags (e.g. `-ad` behaves like `-a -d`)
 - Outputs version, when defined, by using `--version`
 - Outputs description and supplied help text by using `--help`
 - Supports defining `required` options
@@ -27,22 +29,13 @@ Small library to create command-line tool (aka CLI) which is quite similar to [`
 
 ### Recent additions
 
-- Grouped short flags: support clustered short aliases (e.g. `-ad`) where the last short may consume a value when appropriate.
-- Kebab/camel duplication: parsed options are available under both `camelCase` and `kebab-case` keys (e.g. both `dryRun` and `dry-run`).
-- `--` passthrough: tokens after `--` are exposed on `result['--']` and are not parsed as options.
-- Raw argv exposure: the original argv slice is available on `result.__rawArgs` for diagnostics or passthrough adapters.
-- Bare long-form behavior: a bare long option is treated as an empty value (e.g. `--opt` → `''`) and a bare long array option becomes `['']`.
-- Boolean negation parity: negated booleans expose both `noFoo` and `no-foo` keys (e.g. `--no-dry-run` sets `dryRun=false` and also exposes `noDryRun=true` and `no-dry-run=true`).
-- Negation guard: single-dash forms like `-no-foo` / `-noFoo` are treated as negated long options rather than short clusters.
-- Error message consistency: option/argument errors use the `Unknown argument: X` wording to match existing positional error messages.
-
-Short examples:
-
-- Clustered short flags: `-ad` behaves like `-a -d` and `-ab value` lets `b` consume `value` when `b` expects a value.
-- Bare long option: `--bar` (with no following token) results in `bar: ''` for string options.
-
-
-### Install
+- **Interleaved positionals**: positional arguments may appear anywhere in the argument list, interleaved with option flags — e.g. `cmd --flag pos1 --other pos2`. This behavior is enabled by default. Set `command.allowInterleaved = false` to opt out.
+- **Grouped short flags**: clustered short aliases (e.g. `-ad` behaves like `-a -d`); the last short in the cluster may consume the next token as its value.
+**Kebab/camel duplication (default)**: parsed options are available under both `camelCase` and `kebab-case` keys (e.g. both `dryRun` and `dry-run`). Equivalent in yargs: `camel-case-expansion` (enabled by default).
+- **`--` passthrough**: tokens after `--` are exposed on `result['--']` and are not parsed as options.
+- **Raw argv exposure**: the original argv slice is available on `result.__rawArgs` for diagnostics or passthrough adapters.
+- **Bare long-form behavior**: a bare long option with no following value is treated as an empty string (e.g. `--opt` → `''`); a bare long array option becomes `['']`.
+- **Boolean negation parity**: negated booleans expose both `noFoo` and `no-foo` keys (e.g. `--no-dry-run` sets `dryRun=false` and also exposes `noDryRun=true` and `no-dry-run=true`).
 ```sh
 npm install cli-nano
 ```
@@ -209,6 +202,10 @@ serve index.html 7000 --bar
 # Negation parity and passthrough
 serve index.html 7000 --no-dry-run
 serve index.html 7000 -- file.txt --not-a-flag
+
+# Interleaved positionals (enabled by default)
+serve --dryRun index.html 7000 -D value
+serve index.html --exclude dist 7000 -D value
 ```
 
 #### Notes
@@ -228,8 +225,37 @@ serve index.html 7000 -- file.txt --not-a-flag
 - **Raw argv**: The original argv slice is available on `result.__rawArgs` for diagnostics or passthrough adapters.
 - **Negation duplicates**: Using `--no-foo` sets `foo=false` and also exposes `noFoo` and `no-foo` keys.
 - **Alias**: `alias` must be a single string (multi-char aliases are supported). Array-style aliases are not supported and will be rejected.
+- **Interleaved positionals**: Positional arguments may appear anywhere alongside option flags by default. Set `command.allowInterleaved = false` to require positionals-first parsing.
+  - Yargs equivalent: to stop at the first non-option use `parserConfiguration({ 'halt-at-non-option': true })`.
 
 See [examples/](examples/) for more usage patterns.
+
+### Clarifications
+
+- **Subcommand parsing (modes):** cli-nano can be used to parse either a top-level command or a subcommand. When parsing a subcommand, attach the subcommand's options under `command.options` in that subcommand's `Config` so flags are recognized for that subcommand invocation. Example shape:
+
+```ts
+const config = {
+  command: {
+    name: 'exec',
+    positionals: [ /* ... */ ],
+    options: { // subcommand-specific options live here
+      parallel: { type: 'boolean', describe: 'run in parallel' },
+    },
+  },
+  options: { /* top-level options */ },
+};
+```
+
+- **Subcommand options tip:** If you only add flags to the top-level `options` object but intend them for a subcommand, parsing will not recognize them for that subcommand. Put subcommand flags on `config.command.options`.
+
+- **Interleaving vs yargs:** Interleaved positionals are enabled by default in cli-nano (positionals may appear anywhere). To opt out and require positionals-first (yargs' typical `halt-at-non-option` behavior), set:
+
+```ts
+command.allowInterleaved = false;
+```
+
+This makes cli-nano behave like yargs configured with `parserConfiguration({ 'halt-at-non-option': true })`.
 
 ## Help Example
 

--- a/biome.json
+++ b/biome.json
@@ -73,6 +73,8 @@
       "style": {
         "noNonNullAssertion": "off",
         "noParameterAssign": "off",
+        "useBlockStatements": "error",
+        "useConsistentCurlyBraces": "error",
         "useExponentiationOperator": "off"
       },
       "nursery": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "preview:cli:version": "node examples/cli.js --version",
     "prepack": "node scripts/prepack.js",
     "postpack": "node scripts/postpack.js",
-    "test": "vitest --watch --config ./vitest.config.mts",
-    "test:coverage": "vitest --coverage --config ./vitest.config.mts"
+    "test": "vitest --coverage --config ./vitest.config.mts",
+    "test:watch": "vitest --watch --config ./vitest.config.mts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",

--- a/src/__tests__/parse-args.spec.ts
+++ b/src/__tests__/parse-args.spec.ts
@@ -1311,4 +1311,84 @@ describe('parseArgs', () => {
     expect(result.exclude).toEqual(['pattern1', 'pattern2']);
     expect(result.bar).toBe('value');
   });
+
+  describe('allowInterleaved', () => {
+    const interleavedConfig = {
+      ...config,
+      command: { ...config.command, allowInterleaved: true },
+    } as unknown as Config;
+
+    it('should allow positionals to appear after all options', () => {
+      const args = ['--all', '--bar', 'value', 'file1.txt', 'output/'];
+      vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+      const result = parseArgs(interleavedConfig);
+      expect(result.inFile).toBe('file1.txt');
+      expect(result.outDirectory).toBe('output/');
+      expect(result.all).toBe(true);
+      expect(result.bar).toBe('value');
+    });
+
+    it('should allow positionals interleaved between options', () => {
+      const args = ['file1.txt', '--all', 'output/', '--bar', 'value'];
+      vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+      const result = parseArgs(interleavedConfig);
+      expect(result.inFile).toBe('file1.txt');
+      expect(result.outDirectory).toBe('output/');
+      expect(result.all).toBe(true);
+      expect(result.bar).toBe('value');
+    });
+
+    it('should allow a value-consuming option between positionals', () => {
+      const args = ['file1.txt', '--up', '3', 'output/', '--bar', 'value'];
+      vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+      const result = parseArgs(interleavedConfig);
+      expect(result.inFile).toBe('file1.txt');
+      expect(result.outDirectory).toBe('output/');
+      expect(result.up).toBe(3);
+    });
+
+    it('should allow short flags between positionals', () => {
+      const args = ['file1.txt', '-a', 'output/', '--bar', 'value'];
+      vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+      const result = parseArgs(interleavedConfig);
+      expect(result.inFile).toBe('file1.txt');
+      expect(result.outDirectory).toBe('output/');
+      expect(result.all).toBe(true);
+    });
+
+    it('should allow array options interleaved with positionals', () => {
+      const args = ['file1.txt', '--exclude', 'node_modules', 'output/', '--bar', 'value'];
+      vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+      const result = parseArgs(interleavedConfig);
+      expect(result.inFile).toBe('file1.txt');
+      expect(result.outDirectory).toBe('output/');
+      expect(result.exclude).toEqual(['node_modules']);
+    });
+
+    it('should allow negated boolean flags between positionals', () => {
+      const args = ['file1.txt', '--no-dryRun', 'output/', '--bar', 'value'];
+      vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+      const result = parseArgs(interleavedConfig);
+      expect(result.inFile).toBe('file1.txt');
+      expect(result.outDirectory).toBe('output/');
+      expect(result.dryRun).toBe(false);
+    });
+
+    it('should allow short flag clusters between positionals', () => {
+      const args = ['file1.txt', '-ad', 'output/', '--bar', 'value'];
+      vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+      const result = parseArgs(interleavedConfig);
+      expect(result.inFile).toBe('file1.txt');
+      expect(result.outDirectory).toBe('output/');
+      expect(result.all).toBe(true);
+      expect(result.dryRun).toBe(true);
+    });
+  });
+
+  it('should enforce positionals-first when allowInterleaved is false', () => {
+    const cfg: Config = { ...config, command: { ...config.command, allowInterleaved: false } } as any;
+    const args = ['file1.txt', '--all', 'output/', '--bar', 'value'];
+    vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'cli.js', ...args]);
+    expect(() => parseArgs(cfg)).toThrow('Missing required positional argument');
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
   }
   const result: Record<string, any> = {};
 
+  // Interleaved positionals: enabled by default for yargs-like behavior.
+  // Set `command.allowInterleaved = false` to restore traditional positionals-first parsing.
+  const allowInterleaved = (command as any).allowInterleaved !== false;
+
   // Check for duplicate aliases
   const aliasMap = new Map<string, string>();
   for (const [key, opt] of Object.entries(options)) {
@@ -63,15 +67,37 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
     }
   }
 
-  // Handle positional arguments
-  let argIndex = 0;
-  const nonOptionArgs: string[] = [];
-  while (argIndex < args.length && !args[argIndex].startsWith('-')) {
-    nonOptionArgs.push(args[argIndex]);
-    argIndex++;
+  const optionConsumed = new Set<number>();
+  const isSingleDashNegation = (s: string) => /^no-/.test(s);
+  if (allowInterleaved) {
+    for (let i = 0; i < args.length; i++) {
+      const a = args[i];
+      if (!a.startsWith('-')) {
+        continue;
+      }
+      optionConsumed.add(i);
+      const isLong = a.startsWith('--');
+      const body = a.slice(isLong ? 2 : 1);
+      const negated = body.startsWith('no-');
+      const lookup = negated ? body.slice(3) : !isLong && body.length > 1 ? body.slice(-1) : body;
+      const [opt] = findOption(options, lookup);
+      if (opt?.type !== 'boolean' && args[i + 1] && !args[i + 1].startsWith('-')) {
+        optionConsumed.add(i + 1);
+      }
+    }
+  } else {
+    let i = args.findIndex(a => a.startsWith('-'));
+    while (i >= 0 && i < args.length) {
+      optionConsumed.add(i++);
+    }
   }
 
+  const nonOptionIndices = args.map((_, i) => i).filter(i => !optionConsumed.has(i));
+  const nonOptionArgs = nonOptionIndices.map(i => args[i]);
+
+  // Assign positionals from the collected non-option tokens
   let nonOptionIndex = 0;
+  const positionalConsumed = new Set<number>();
   for (let i = 0; i < positionals.length; i++) {
     const pos = positionals[i];
     if (pos.variadic) {
@@ -82,6 +108,9 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
         throw new Error(`Missing required positional argument, i.e.: "${command.name} ${usagePositionals}"`);
       }
       result[pos.name] = !pos.required && values.length === 0 && pos.default !== undefined ? pos.default : values;
+      for (let j = nonOptionIndex; j < nonOptionIndex + values.length; j++) {
+        positionalConsumed.add(nonOptionIndices[j]);
+      }
       nonOptionIndex += values.length;
     } else {
       const value = nonOptionArgs[nonOptionIndex];
@@ -90,6 +119,7 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
       const argsLeft = nonOptionArgs.length - nonOptionIndex;
       if (value !== undefined && (argsLeft > requiredLeft - (pos.required ? 1 : 0) || pos.required)) {
         result[pos.name] = value;
+        positionalConsumed.add(nonOptionIndices[nonOptionIndex]);
         nonOptionIndex++;
       } else if (!pos.required && pos.default !== undefined) {
         result[pos.name] = pos.default;
@@ -100,28 +130,9 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
     }
   }
 
-  // Handle options
-  argIndex = 0;
-  const consumedArgs = new Set<number>();
-  // Mark all nonOptionArgs indices as consumed for positionals
-  let tempNonOptionIndex = 0;
-  for (let i = 0; i < positionals.length; i++) {
-    const pos = positionals[i];
-    if (pos.variadic) {
-      const remaining = positionals.length - (i + 1);
-      const values = nonOptionArgs.slice(tempNonOptionIndex, nonOptionArgs.length - remaining);
-      for (let j = tempNonOptionIndex; j < tempNonOptionIndex + values.length; j++) {
-        consumedArgs.add(args.findIndex((a, idx) => !a.startsWith('-') && !consumedArgs.has(idx) && a === nonOptionArgs[j]));
-      }
-      tempNonOptionIndex += values.length;
-    } else {
-      const value = nonOptionArgs[tempNonOptionIndex++];
-      consumedArgs.add(args.findIndex((a, idx) => !a.startsWith('-') && !consumedArgs.has(idx) && a === value));
-    }
-  }
-
+  let argIndex = 0;
   while (argIndex < args.length) {
-    if (consumedArgs.has(argIndex)) {
+    if (positionalConsumed.has(argIndex)) {
       argIndex++;
       continue;
     }
@@ -143,9 +154,8 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
 
         // If this exact token matches an option (rare), prefer that (e.g. -xy where xy is alias)
         [option, configKey] = findOption(options, body);
-        // Avoid treating `-no-foo` or `-noFoo` as a short-char cluster — those are
-        // negated long forms and should be handled by the negation branch below.
-        if (!option && body.length > 1 && !/^no-/.test(body) && !/^no[A-Z]/.test(body)) {
+        // Avoid treating `-no-foo` as a short-char cluster — it's a negated long form.
+        if (!option && body.length > 1 && !isSingleDashNegation(body)) {
           // Treat as a cluster of single-char aliases
           const chars = body.split('');
           for (let ci = 0; ci < chars.length; ci++) {
@@ -157,7 +167,6 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
             }
 
             if (!isLast) {
-              // Middle flags must be boolean
               if (cOpt.type !== 'boolean') {
                 throw new Error(`Missing value for option: ${cKey}`);
               }
@@ -166,31 +175,25 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
               }
               result[cKey] = true;
             } else {
-              // Last flag: if boolean, set true; otherwise consume next token as its value
               if (cOpt.type === 'boolean') {
                 if (result[cKey] !== undefined) {
                   throw new Error('Providing same negated and truthy argument are not allowed');
                 }
                 result[cKey] = true;
-              } else if (cOpt.type === 'number') {
-                if (args[argIndex + 1] === undefined || args[argIndex + 1].startsWith('-')) {
-                  throw new Error(`Missing value for option: ${cKey}`);
-                }
-                result[cKey] = Number(args[++argIndex]);
               } else if (cOpt.type === 'array') {
                 if (!result[cKey]) {
                   result[cKey] = [];
                 }
-                const arrayValue = args[++argIndex];
-                if (arrayValue === undefined || arrayValue.startsWith('-')) {
+                const v = args[++argIndex];
+                if (v === undefined || v.startsWith('-')) {
                   throw new Error(`Missing value for array option: ${cKey}`);
                 }
-                result[cKey].push(arrayValue);
+                result[cKey].push(v);
               } else {
                 if (args[argIndex + 1] === undefined || args[argIndex + 1].startsWith('-')) {
                   throw new Error(`Missing value for option: ${cKey}`);
                 }
-                result[cKey] = args[++argIndex];
+                result[cKey] = cOpt.type === 'number' ? Number(args[++argIndex]) : args[++argIndex];
               }
             }
           }
@@ -201,7 +204,7 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
         }
       }
 
-      // Handle negated boolean in both forms
+      // Handle negated boolean (`no-foo` form)
       if (!option) {
         const isNegated = arg.startsWith('no-');
         const optionName = isNegated ? arg.slice(3) : arg;
@@ -213,7 +216,7 @@ export function parseArgs<C extends Config>(config: C): ArgsResult<C> {
             throw new Error('Providing same negated and truthy argument are not allowed');
           }
           result[configKey] = !isNegated;
-          // When explicitly negated (e.g. --no-foo) also expose `noFoo` and `no-foo` keys
+          // When explicitly negated also expose `noFoo` and `no-foo` keys
           if (isNegated) {
             const kebabKey = camelToKebab(configKey);
             const noCamel = `no${configKey[0].toUpperCase()}${configKey.slice(1)}`;


### PR DESCRIPTION
- Enable interleaved positional arguments (positionals may appear anywhere); opt-out with `command.allowInterleaved = false`.  
- Preserve existing semantics (short clusters, --no negation, kebab/camel duplicates); tests and README updated.